### PR TITLE
fix: remove unreachable branch in node_execution_summary

### DIFF
--- a/crates/weft-core/src/executor_core.rs
+++ b/crates/weft-core/src/executor_core.rs
@@ -215,8 +215,6 @@ pub fn node_execution_summary(executions: &[NodeExecution]) -> String {
     let failed = executions.iter().filter(|e| e.status == NodeExecutionStatus::Failed).count();
     let completed = executions.iter().filter(|e| e.status == NodeExecutionStatus::Completed).count();
     let skipped = executions.iter().filter(|e| e.status == NodeExecutionStatus::Skipped).count();
-
-
     let cancelled = executions.iter().filter(|e| e.status == NodeExecutionStatus::Cancelled).count();
 
     let base = if running > 0 {
@@ -227,8 +225,6 @@ pub fn node_execution_summary(executions: &[NodeExecution]) -> String {
         "skipped"
     } else if failed > 0 && completed == 0 {
         "failed"
-    } else if failed > 0 {
-        "completed"
     } else {
         "completed"
     };


### PR DESCRIPTION
<!--
Thanks for sending a PR. Before opening it, please:
1. Read CONTRIBUTING.md if you have not already.
2. For medium or large changes, open an issue first and wait for a thumbs up.
3. Make sure tests and lints pass locally.
-->

## What and why

`node_execution_summary` had a dead `else if failed > 0` branch that returned `"completed"`, the same value as the fall through `else`. The branch was unreachable. 

## How

Remove the two dead lines. The existing tests confirm this is a no-op.

## Linked issue

X

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] New node
- [ ] Language change (parser, type system, executor)
- [ ] Dashboard change
- [ ] Docs
- [X] Refactor
- [ ] Other:

## Checklist

- [X] `cargo build`, `cargo test`, and `cargo clippy` pass.
- [ ] `pnpm -C dashboard check` passes (if frontend changed).
- [ ] New code has tests. Bug fixes have a regression test.
- [X] No unrelated formatting churn.
- [X] No commented-out code.
- [ ] No `TODO` or `FIXME` without a linked issue.
- [ ] If this is a node, backend and frontend port names/types match, and I built a tiny project that uses it end to end.
- [ ] If this is a language change, I opened an issue first and it was approved.

## Screenshots / demo (if applicable)

X

## Anything reviewers should pay extra attention to

X
