### PR TITLE
fix: HTTP node now forwards headers input to the request

### DIFF
--- a/catalog/enrichment/http/backend.rs
+++ b/catalog/enrichment/http/backend.rs
@@ -37,30 +37,42 @@ impl Node for HttpNode {
     }
 
     async fn execute(&self, ctx: ExecutionContext) -> NodeResult {
-        let client = reqwest::Client::new();
-        
         let url = ctx.config.get("url")
             .or_else(|| ctx.input.get("url"))
             .and_then(|v| v.as_str())
             .unwrap_or("https://httpbin.org/get");
-        
+
         let method = ctx.config.get("method")
             .and_then(|v| v.as_str())
             .unwrap_or("GET");
 
         tracing::info!("HTTP request: {} {}", method, url);
 
+        let mut header_map = reqwest::header::HeaderMap::new();
+        if let Some(headers_obj) = ctx.input.get("headers").and_then(|v| v.as_object()) {
+            for (key, value) in headers_obj {
+                if let (Ok(name), Some(val)) = (
+                    reqwest::header::HeaderName::from_bytes(key.as_bytes()),
+                    value.as_str().and_then(|v| reqwest::header::HeaderValue::from_str(v).ok()),
+                ) {
+                    header_map.insert(name, val);
+                }
+            }
+        }
+
+        let client = &ctx.http_client;
+
         let result = match method.to_uppercase().as_str() {
             "POST" => {
                 let body = ctx.input.get("body").cloned().unwrap_or(serde_json::json!({}));
-                client.post(url).json(&body).send().await
+                client.post(url).headers(header_map).json(&body).send().await
             }
             "PUT" => {
                 let body = ctx.input.get("body").cloned().unwrap_or(serde_json::json!({}));
-                client.put(url).json(&body).send().await
+                client.put(url).headers(header_map).json(&body).send().await
             }
-            "DELETE" => client.delete(url).send().await,
-            _ => client.get(url).send().await,
+            "DELETE" => client.delete(url).headers(header_map).send().await,
+            _ => client.get(url).headers(header_map).send().await,
         };
 
         match result {


### PR DESCRIPTION
<!--
Thanks for sending a PR. Before opening it, please:
1. Read CONTRIBUTING.md if you have not already.
2. For medium or large changes, open an issue first and wait for a thumbs up.
3. Make sure tests and lints pass locally.
-->

## What and why

The HTTP node declares a headers: Dict[String, String] input port but never reads it. Any headers wired in are silently dropped.

## How

Read the headers input port in execute and forward each key-value pair into a reqwest::HeaderMap. Also switch from reqwest::Client::new() on every call to the shared ctx.http_client.

## Linked issue

X

## Type of change

- [X] Bug fix
- [ ] New feature
- [ ] New node
- [ ] Language change (parser, type system, executor)
- [ ] Dashboard change
- [ ] Docs
- [ ] Refactor
- [ ] Other:

## Checklist

- [X] `cargo build`, `cargo test`, and `cargo clippy` pass.
- [ ] `pnpm -C dashboard check` passes (if frontend changed).
- [ ] New code has tests. Bug fixes have a regression test.
- [X] No unrelated formatting churn.
- [X] No commented-out code.
- [X] No `TODO` or `FIXME` without a linked issue.
- [ ] If this is a node, backend and frontend port names/types match, and I built a tiny project that uses it end to end.
- [ ] If this is a language change, I opened an issue first and it was approved.

## Screenshots / demo (if applicable)

X

## Anything reviewers should pay extra attention to

X