### PR TITLE
fix: date node now applies the format field

### DIFF
--- a/catalog/data/primitives/date/backend.rs
+++ b/catalog/data/primitives/date/backend.rs
@@ -33,9 +33,24 @@ impl Node for DateNode {
 
     async fn execute(&self, ctx: ExecutionContext) -> NodeResult {
         let default_date = chrono::Utc::now().to_rfc3339();
-        let value = ctx.config.get("value")
+        let raw = ctx.config.get("value")
             .and_then(|v| v.as_str())
             .unwrap_or(&default_date);
+
+        let format = ctx.config.get("format")
+            .and_then(|v| v.as_str())
+            .unwrap_or("ISO");
+
+        let value = match format {
+            "Unix" => {
+                let ts = chrono::DateTime::parse_from_rfc3339(raw)
+                    .map(|d| d.timestamp())
+                    .unwrap_or_else(|_| chrono::Utc::now().timestamp());
+                ts.to_string()
+            }
+            _ => raw.to_string(),
+        };
+
         NodeResult::completed(serde_json::json!({ "value": value }))
     }
 }


### PR DESCRIPTION
<!--
Thanks for sending a PR. Before opening it, please:
1. Read CONTRIBUTING.md if you have not already.
2. For medium or large changes, open an issue first and wait for a thumbs up.
3. Make sure tests and lints pass locally.
-->

## What and why

The Date node offers ISO / Unix / Custom format options in the UI but the backend never reads the format config field. It always returns the raw string regardless of what the user selects.

## How

Read format from config in execute. For "Unix", parse the value as RFC 3339 and emit seconds since epoch. ISO and Custom pass through unchanged.

## Linked issue

X

## Type of change

- [X] Bug fix
- [ ] New feature
- [ ] New node
- [ ] Language change (parser, type system, executor)
- [ ] Dashboard change
- [ ] Docs
- [ ] Refactor
- [ ] Other:

## Checklist

- [X] `cargo build`, `cargo test`, and `cargo clippy` pass.
- [ ] `pnpm -C dashboard check` passes (if frontend changed).
- [ ] New code has tests. Bug fixes have a regression test.
- [X] No unrelated formatting churn.
- [X] No commented-out code.
- [X] No `TODO` or `FIXME` without a linked issue.
- [ ] If this is a node, backend and frontend port names/types match, and I built a tiny project that uses it end to end.
- [ ] If this is a language change, I opened an issue first and it was approved.

## Screenshots / demo (if applicable)

X

## Anything reviewers should pay extra attention to

X
