### PR TITLE
Prevent inactive projects from executing webhook triggers

### DIFF
--- a/crates/weft-api/src/webhooks.rs
+++ b/crates/weft-api/src/webhooks.rs
@@ -23,6 +23,10 @@ pub struct WebhookResponse {
     pub message: String,
 }
 
+fn webhook_trigger_is_active(status: &str) -> bool {
+    status == "running"
+}
+
 /// Handle incoming webhook calls
 /// URL format: /api/v1/webhooks/{trigger_id}
 /// 
@@ -64,6 +68,21 @@ pub async fn handle_webhook(
             );
         }
     };
+
+    if !webhook_trigger_is_active(&trigger.status) {
+        tracing::info!(
+            "Ignoring webhook for inactive trigger {} with status {}",
+            trigger_id,
+            trigger.status
+        );
+        return (
+            StatusCode::CONFLICT,
+            Json(WebhookResponse {
+                status: "ignored".to_string(),
+                message: "Trigger is inactive".to_string(),
+            }),
+        );
+    }
 
     // Verify trigger category is Webhook
     if trigger.triggerCategory != "Webhook" {
@@ -328,4 +347,18 @@ fn headers_to_json(headers: &HeaderMap) -> serde_json::Value {
         }
     }
     serde_json::Value::Object(map)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::webhook_trigger_is_active;
+
+    #[test]
+    fn webhook_only_runs_for_running_triggers() {
+        assert!(webhook_trigger_is_active("running"));
+        assert!(!webhook_trigger_is_active("pending"));
+        assert!(!webhook_trigger_is_active("setup_pending"));
+        assert!(!webhook_trigger_is_active("stopped"));
+        assert!(!webhook_trigger_is_active("failed"));
+    }
 }


### PR DESCRIPTION
## What and why

This change stops inactive projects from still executing when their webhook URL is hit. The bug was that deactivating a project stopped the trigger in state, but the webhook handler still accepted the trigger ID and launched a run anyway, which could keep generating load from projects that were supposed to be off.

## How

The webhook handler now checks the trigger status before starting an execution and only proceeds when the trigger is actually `running`. If the trigger has been deactivated or is otherwise inactive, the request is ignored instead of starting the workflow. I also added a small regression test around that status guard.

## Linked issue

Closes #8

## Type of change

- [X] Bug fix
- [ ] New feature
- [ ] New node
- [ ] Language change (parser, type system, executor)
- [ ] Dashboard change
- [ ] Docs
- [ ] Refactor
- [ ] Other:

## Checklist

- [ ] `cargo build`, `cargo test`, and `cargo clippy` pass.
- [ ] `pnpm -C dashboard check` passes (if frontend changed).
- [X] New code has tests. Bug fixes have a regression test.
- [X] No unrelated formatting churn.
- [X] No commented-out code.
- [X] No `TODO` or `FIXME` without a linked issue.
- [ ] If this is a node, backend and frontend port names/types match, and I built a tiny project that uses it end to end.
- [ ] If this is a language change, I opened an issue first and it was approved.

## Screenshots / demo (if applicable)

Not applicable.

## Anything reviewers should pay extra attention to

The important bit is that this fix is intentionally server-side and narrow. It does not change the activation/deactivation flow itself; it closes the gap where an existing webhook URL could still trigger execution after the trigger had been marked inactive. I couldn’t mark the full Rust checklist as passing because the workspace currently has an unrelated compile issue in `weft-nodes` that blocked a complete test run.