### PR TITLE
fix: classify loom attributes structurally, report bare `key=`

### DIFF
--- a/dashboard/src/lib/ai/loom-parser.test.ts
+++ b/dashboard/src/lib/ai/loom-parser.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from 'vitest';
+import { parseLoom } from './loom-parser';
+import type { Brick } from '$lib/types';
+
+/** Wrap raw loom in a 4-backtick fence so parseLoom can extract it. */
+function loom(code: string) {
+	return '````loom\n' + code.trim() + '\n````';
+}
+
+/** Parse loom and return the first brick of the given kind. */
+function firstBrick(code: string, kind: string): Brick {
+	const { manifest } = parseLoom(loom(code));
+	expect(manifest).not.toBeNull();
+	const found = (manifest!.blocks ?? [])
+		.filter(b => b.kind === 'brick')
+		.map(b => (b as { kind: 'brick'; brick: Brick }).brick)
+		.find(b => b.kind === kind);
+	expect(found, `no ${kind} brick parsed`).toBeDefined();
+	return found!;
+}
+
+function errorsFor(code: string) {
+	return parseLoom(loom(code)).errors.map(e => e.message);
+}
+
+describe('attribute vs positional classification', () => {
+	it('keeps a positional string that contains a colon', () => {
+		// `includes(':')` misread this as an attribute and split it at the first
+		// colon, so `content` came back undefined and the text vanished.
+		const brick = firstBrick('text "Runs 9:00 to 17:00"', 'text');
+		expect(brick.props.content).toBe('Runs 9:00 to 17:00');
+	});
+
+	it('keeps a positional string containing a URL', () => {
+		const brick = firstBrick('text "Docs: https://example.com"', 'text');
+		expect(brick.props.content).toBe('Docs: https://example.com');
+	});
+
+	it('keeps positional content alongside real attributes', () => {
+		const brick = firstBrick(
+			'feature icon:"clock" title:"Scheduled" "Fires at 06:30 UTC"',
+			'feature'
+		);
+		expect(brick.props.icon).toBe('clock');
+		expect(brick.props.title).toBe('Scheduled');
+		expect(brick.props.content).toBe('Fires at 06:30 UTC');
+	});
+
+	it('still parses ordinary attributes and content', () => {
+		const brick = firstBrick(
+			'feature icon:"shield" title:"Verify evidence" "Every finding is checked."',
+			'feature'
+		);
+		expect(brick.props.title).toBe('Verify evidence');
+		expect(brick.props.content).toBe('Every finding is checked.');
+	});
+
+	it('keeps an attribute value that contains a colon', () => {
+		const brick = firstBrick('hero title:"Ships fast" subtitle:"Note: it is fast"', 'hero');
+		expect(brick.props.subtitle).toBe('Note: it is fast');
+	});
+
+	it('preserves a phase description containing a colon', () => {
+		const { manifest } = parseLoom(loom('phase "Configure" "Runs at 9:00" {\n}'));
+		expect(manifest!.phases[0].description).toBe('Runs at 9:00');
+	});
+});
+
+describe('key= instead of key:', () => {
+	it('reports a bare key= rather than absorbing it as body text', () => {
+		const src = 'feature icon:"shield" title="Verify evidence" "Every finding is checked."';
+		const messages = errorsFor(src);
+		expect(messages).toContainEqual(expect.stringContaining("Did you mean 'title:'?"));
+
+		// The malformed token must not leak into the rendered copy.
+		const brick = firstBrick(src, 'feature');
+		expect(brick.props.content).toBe('Every finding is checked.');
+	});
+
+	it('reports key= on a phase line', () => {
+		expect(errorsFor('phase "Configure" description="Set up" {\n}')).toContainEqual(
+			expect.stringContaining("Did you mean 'description:'?")
+		);
+	});
+
+	it('does not flag an equals sign inside a quoted value', () => {
+		expect(errorsFor('text "a = b"')).toEqual([]);
+	});
+});

--- a/dashboard/src/lib/ai/loom-parser.ts
+++ b/dashboard/src/lib/ai/loom-parser.ts
@@ -481,6 +481,25 @@ function isBrickKind(s: string): s is BrickKind {
 	return (BRICK_KINDS as readonly string[]).includes(s);
 }
 
+/** An attribute token is an identifier followed by `:`, or a bracket group. */
+const ATTR_TOKEN_RE = /^[A-Za-z][A-Za-z0-9_.-]*:/;
+
+/** `key=` where `key:` was meant. The most common way to mistype an attribute. */
+const BARE_EQUALS_RE = /^([A-Za-z][A-Za-z0-9_.-]*)=/;
+
+function isAttrToken(t: string): boolean {
+	if (t.startsWith('[') && t.endsWith(']')) return true;
+	return ATTR_TOKEN_RE.test(t);
+}
+
+/** Report `key="value"` tokens instead of absorbing them as positional text. */
+function reportBareEquals(tokens: string[], state: ParseState, lineNum: number): void {
+	for (const t of tokens) {
+		const m = BARE_EQUALS_RE.exec(t);
+		if (m) state.errors.push({ line: lineNum, message: `Unknown attribute syntax '${m[1]}='. Did you mean '${m[1]}:'?` });
+	}
+}
+
 // Bricks that can contain nested children.
 const NESTABLE_BRICKS: ReadonlySet<BrickKind> = new Set<BrickKind>([
 	'columns', 'card', 'tabs', 'tab', 'feature-grid', 'faq', 'stats',
@@ -664,6 +683,7 @@ function parseThemeBody(state: ParseState): RunnerTheme {
 function parsePhase(state: ParseState): SetupPhase | null {
 	const rawLine = state.lines[state.pos];
 	const trimmed = rawLine.trim();
+	const lineNum = state.pos + 1;
 	state.pos++;
 	const rest = trimmed.slice('phase'.length).trim();
 	const hasBlock = rest.endsWith('{');
@@ -671,8 +691,9 @@ function parsePhase(state: ParseState): SetupPhase | null {
 	const tokens = tokenizeLine(cleaned);
 	const title = tokens[0] ? parseQuotedString(tokens[0]) : 'Untitled';
 	const remaining = tokens.slice(1);
-	const positionalDesc = remaining[0] && !remaining[0].includes(':') ? parseQuotedString(remaining[0]) : undefined;
-	const attrs = parseAttributes(remaining.filter(t => t.includes(':')));
+	const positionalDesc = remaining[0] && !isAttrToken(remaining[0]) ? parseQuotedString(remaining[0]) : undefined;
+	const attrs = parseAttributes(remaining.filter(isAttrToken));
+	reportBareEquals(remaining, state, lineNum);
 	const description = positionalDesc ?? attrs.description;
 
 	const phase: SetupPhase = {
@@ -763,15 +784,19 @@ function parseBrick(state: ParseState, lineNum: number): Brick | null {
 		return null;
 	}
 
-	// Positional content: anything before the first `key:` token is positional.
+	// Split attributes from positional content. A token counts as an attribute
+	// only if it *starts* with `key:`; testing for a colon anywhere would read a
+	// positional string that merely contains one ("Runs 9:00 to 17:00") as an
+	// attribute and split it at the wrong place, losing the text entirely.
 	const rest = tokens.slice(1);
 	const positional: string[] = [];
 	const attrTokens: string[] = [];
 	for (const t of rest) {
-		if (t.includes(':') && !t.startsWith('[')) attrTokens.push(t);
-		else if (t.startsWith('[') && t.endsWith(']')) attrTokens.push(t);
+		if (isAttrToken(t)) attrTokens.push(t);
+		else if (BARE_EQUALS_RE.test(t)) continue; // reported below, never silently absorbed
 		else positional.push(parseQuotedString(t));
 	}
+	reportBareEquals(rest, state, lineNum);
 	const attrs = parseAttributes(attrTokens);
 
 	const props: Record<string, unknown> = { ...attrs };


### PR DESCRIPTION
`parseBrick` decided attribute-vs-positional with `t.includes(':')`. Two silent failures fall out of that.

**A positional string containing a colon was destroyed.** It got classified as an attribute and split at `indexOf(':')`, so `text "Runs 9:00 to 17:00"` produced `{'"Runs 9': '00 to 17:00"'}` and `content` came back `undefined`. The text didn't render wrong, it disappeared. Times, URLs and ordinary prose all hit it. `parsePhase` had the same test and lost phase descriptions the same way.

**A `key="value"` token was absorbed into body text.** No colon, so it fell to the positional branch. A published page of mine rendered the literal string `title="Verify evidence"` to visitors for a day, with no diagnostic at edit, save, publish or render. The loom had been generated by the Tangle Runner Page Builder, which is the part I'd flag hardest: the builder makes this mistake and nothing catches it.

### The change

Classify on `^[A-Za-z][A-Za-z0-9_.-]*:`, so a token is an attribute only when it starts with one, and push a `LoomParseError` naming the key when a bare `key=` appears. `state.errors` and `LoomParseError` already exist and are used two lines up for `Unknown brick`, so this reaches for the channel that's already there rather than adding one.

I read this as applying CONTRIBUTING's "do not add silent fallbacks, fail loud" to the loom parser, and as the same remedy the roadmap already picked for explicit expand/gather: implicit behaviour that AI writers confuse and that produces wrong data quietly, made explicit.

### Tests

New `dashboard/src/lib/ai/loom-parser.test.ts`, 9 cases. **6 fail on `main`** and pass with the change; the other 3 are regression guards for behaviour that already worked (ordinary attributes, attribute values containing colons, `=` inside a quoted string).

### Checks

- `npx vitest run src/lib/ai/loom-parser.test.ts` — 9 passed
- `pnpm -C dashboard check` — 4850 files, 0 errors, 0 warnings
- Full `vitest run` — 263 pre-existing failures on `main` *and* on this branch, all catalog-dependent (I hadn't run `scripts/catalog-link.sh`). Delta is +9 passing, no change in failures.

### Reproduction without applying the patch

`tokenizeLine`, `parseAttributes` and `parseBrick`'s classifier transcribed verbatim from `main`, with cases: [loom-parser-repro.mjs](https://github.com/JeremyGracey-AI/governance-drift-researcher/blob/main/loom-parser-repro.mjs). `node loom-parser-repro.mjs`, no account or clone needed.

Fuller write-up of how this surfaced, plus a few smaller publish-flow observations that are not part of this PR: [UPSTREAM-REPORT.md](https://github.com/JeremyGracey-AI/governance-drift-researcher/blob/main/UPSTREAM-REPORT.md).

### Known remaining edge, not addressed here

Bracket-group attributes (`[label:"a:b"]`) are expanded by `tokenizeLine` and still run through `parseAttributes`'s `indexOf(':')`, so a colon inside a bracketed value can still split in the wrong place. Left alone to keep this to one function. Happy to follow up if you want it in scope.

### On the roadmap

I know "Centralize parsing and compilation in Rust" covers this file. This is deliberately small enough to carry over as test cases if the TypeScript parser goes away. Close it if you'd rather not touch the dashboard parser at all, no hard feelings, the bug report stands on its own.
