### PR TITLE
fix(setup): measure target/ with POSIX du so macOS re-runs work

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -742,7 +742,20 @@ if [[ $build_cli -eq 1 ]]; then
     # setup, and the case where the cap matters most) measures as 0
     # without it. A non-numeric measurement skips the cap (wiping on
     # an unreadable measurement is the dangerous direction).
-    target_gb="$(du -sBG -L "${here}/target" 2>/dev/null | tail -n1 | cut -f1 | tr -d 'G')"
+    # POSIX `du -sk`, not GNU's `-BG`: BSD du (macOS) rejects `-BG` with
+    # a usage error (exit 64), and under `set -euo pipefail` that aborted
+    # the entire install. It only bit on the SECOND install onward, since
+    # the first has no target/ yet and the guard above skips it, which is
+    # why it survived: `./setup.sh` is documented as re-runnable.
+    # `|| true` keeps a partial-read failure on the "could not measure"
+    # path below rather than killing the script.
+    target_kb="$(du -sk -L "${here}/target" 2>/dev/null | tail -n1 | cut -f1 || true)"
+    # KiB -> whole GiB, rounded UP so the cap keeps GNU `-BG`'s ceiling.
+    if [[ "${target_kb}" =~ ^[0-9]+$ ]]; then
+      target_gb=$(( (target_kb + 1048575) / 1048576 ))
+    else
+      target_gb=""
+    fi
     if [[ ! "${target_gb}" =~ ^[0-9]+$ ]]; then
       warn "could not measure target/; skipping the size cap"
     elif [[ "${target_gb}" -gt "${target_cap_gb}" ]]; then


### PR DESCRIPTION
## What and why

`./setup.sh` fails on macOS on every run after the first. `du -sBG` is GNU
syntax; BSD `du` rejects it with a usage error and exit 64, and under
`set -euo pipefail` that kills the install before anything is built.

Both the README and `docs/getting-started.md` document the script as
re-runnable ("Re-run `./setup.sh` anytime to rebuild"), so on macOS that
instruction currently cannot be followed.

## How

Swap the GNU-only `du -sBG` for POSIX `du -sk` and convert KiB to whole GiB,
rounding **up** so the cap keeps `-BG`'s ceiling semantics and behaves
identically. `|| true` routes a partial-read failure onto the existing
"could not measure target/; skipping the size cap" branch rather than
aborting the install.

```diff
-target_gb="$(du -sBG -L "${here}/target" 2>/dev/null | tail -n1 | cut -f1 | tr -d 'G')"
+target_kb="$(du -sk -L "${here}/target" 2>/dev/null | tail -n1 | cut -f1 || true)"
+if [[ "${target_kb}" =~ ^[0-9]+$ ]]; then
+  target_gb=$(( (target_kb + 1048575) / 1048576 ))
+else
+  target_gb=""
+fi
```

## Reproduce

```bash
git clone https://github.com/WeaveMindAI/weft.git && cd weft
git checkout mvp
./setup.sh          # succeeds, creates target/
./setup.sh --cli    # fails, exit 64
```

```
$ du -sBG -L ./target
du: invalid argument to option B: G
usage: du [-Aclnx] [-H | -L | -P] [-g | -h | -k | -m] ...
$ echo $?
64
```

Because `2>/dev/null` hides the usage error, the script prints no cause;
`~/.local/share/weft/setup-runs.log` records only `FAIL exit=64 in section CLI`.

## Base branch

Targeting **`mvp`**, not `main`, deliberately: `setup.sh` does not exist on
`main` (v1 architecture), so this only applies here. Flagging it since recent
PRs default to `main`.

## Linked issue

None — filing directly per CONTRIBUTING ("For small changes, just open a PR...
obvious bugs. No discussion needed.").

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] New node
- [ ] Language change (parser, type system, executor)
- [ ] Dashboard change
- [ ] Docs
- [ ] Refactor
- [ ] Other:

## Checklist

- [x] Shell-only change; `bash -n setup.sh` parses clean and a full
      `./setup.sh --cli --daemon` now completes on macOS (it failed before).
      No Rust or frontend code touched, so `cargo`/`pnpm` gates are unaffected.
- [ ] `pnpm -C dashboard check` passes (if frontend changed). — n/a
- [x] No unrelated formatting churn.
- [x] No commented-out code.
- [x] No `TODO` or `FIXME` without a linked issue.

## Environment it was found on

macOS 26 (Darwin 25.6.0, arm64), `bash` 5.3.15 from Homebrew (i.e. the
documented `brew install bash` was done), `mvp` @ `0a5339f`.

## Anything reviewers should pay extra attention to

Two things I chose not to fold in, to keep this reviewable:

1. **Rounding.** GNU `-BG` rounds up, so I kept a ceiling rather than
   truncating. At a 60 GiB cap the difference is cosmetic, but matching the
   old behaviour exactly seemed better than quietly changing when the cap trips.

2. **`stat -c %Y` (two call sites in the same section) is also GNU-only.**
   It is not fatal thanks to the `|| echo 0` fallback, but on macOS both
   `pre_mtime` and `post_mtime` become `0` and therefore always compare equal,
   so the script concludes the binary did not change and **skips the stale
   worker-image prune on every macOS build**. Happy to fix in a separate PR if
   you want it — it felt like a different bug from this one.