### PR TITLE
staging

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -234,7 +234,11 @@ jobs:
       - run: pnpm -C extension-vscode run compile
       - run: pnpm -C extension-vscode run bundle:webview
       - run: pnpm -C extension-vscode run bundle:markdown-preview
-      - run: pnpm -C extension-vscode dlx @vscode/vsce@3.9.2 package --no-dependencies --allow-missing-repository --skip-license
+      # working-directory, not `pnpm -C`: dlx spawns the tool in the
+      # PROCESS cwd, so with -C vsce would look for package.json at the
+      # repo root and refuse.
+      - run: pnpm dlx @vscode/vsce@3.9.2 package --no-dependencies --allow-missing-repository --skip-license
+        working-directory: extension-vscode
       # One stable asset name; the version lives in manifest.json and
       # in the package itself.
       # SYNC: vsix asset name <-> setup.sh (prebuilt artifacts block:

--- a/crates/weft-cli/src/main.rs
+++ b/crates/weft-cli/src/main.rs
@@ -63,7 +63,9 @@ enum Cmd {
         /// architecture on its native runner with `-amd64` / `-arm64`
         /// here, then stitches the bare ref into one multi-arch
         /// manifest list, so every machine pulls its own architecture.
-        #[arg(long, value_name = "SUFFIX")]
+        /// `allow_hyphen_values`: the suffixes start with a hyphen
+        /// (`-amd64`), which clap would otherwise read as flags.
+        #[arg(long, value_name = "SUFFIX", allow_hyphen_values = true)]
         push_suffix: Option<String>,
         /// Only print the refs this tree resolves to, one per line,
         /// touching nothing (no ensure, no docker). What setup.sh


### PR DESCRIPTION
- **ci/cd: full release pipeline, prebuilt install fast path, and a deep review pass**
- **ci: install the toolchain with bare rustup, not the pinned action**
- **release: fix the two first-run breakages**
