### PR TITLE
staging

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -234,10 +234,13 @@ jobs:
       - run: pnpm -C extension-vscode run compile
       - run: pnpm -C extension-vscode run bundle:webview
       - run: pnpm -C extension-vscode run bundle:markdown-preview
+      # The repo LICENSE rides inside the .vsix (both stores refuse a
+      # licenseless extension); copied, not tracked twice.
+      - run: cp LICENSE extension-vscode/LICENSE
       # working-directory, not `pnpm -C`: dlx spawns the tool in the
       # PROCESS cwd, so with -C vsce would look for package.json at the
       # repo root and refuse.
-      - run: pnpm dlx @vscode/vsce@3.9.2 package --no-dependencies --allow-missing-repository --skip-license
+      - run: pnpm dlx @vscode/vsce@3.9.2 package --no-dependencies
         working-directory: extension-vscode
       # One stable asset name; the version lives in manifest.json and
       # in the package itself.

--- a/extension-vscode/.gitignore
+++ b/extension-vscode/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 out/
 *.vsix
 .vscode-test/
+LICENSE

--- a/extension-vscode/package.json
+++ b/extension-vscode/package.json
@@ -4,6 +4,11 @@
   "description": "Weft language support: project management against the local dispatcher, live graph view for .weft files, AI streaming edits.",
   "version": "0.2.237",
   "publisher": "weavemind",
+  "license": "SEE LICENSE IN LICENSE",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/WeaveMindAI/weft"
+  },
   "packageManager": "pnpm@10.32.1",
   "engines": {
     "vscode": "^1.90.0"

--- a/setup.sh
+++ b/setup.sh
@@ -1827,8 +1827,10 @@ if [[ $build_vscode -eq 1 ]]; then
     spin "vite bundle webview" pnpm run bundle:webview
     spin "vite bundle markdown preview" pnpm run bundle:markdown-preview
     rm -f weft-vscode-*.vsix
-    spin "package .vsix" pnpm dlx @vscode/vsce package \
-      --no-dependencies --allow-missing-repository --skip-license
+    # The repo LICENSE rides inside the .vsix (the stores refuse a
+    # licenseless extension; the local package matches CI's).
+    cp "${here}/LICENSE" LICENSE
+    spin "package .vsix" pnpm dlx @vscode/vsce package --no-dependencies
     mkdir -p "${hash_dir}"
     printf '%s' "${current_hash}" >"${hash_file}"
   fi


### PR DESCRIPTION
- **ci/cd: full release pipeline, prebuilt install fast path, and a deep review pass**
- **ci: install the toolchain with bare rustup, not the pinned action**
- **release: fix the two first-run breakages**
- **release: create the Open VSX namespace on first publish**
- **vscode extension: ship the license and repository metadata**
