### PR TITLE
release: a store that already has the version is published, not a failure

### DIFF
--- a/.github/actions/publish-and-record/action.yml
+++ b/.github/actions/publish-and-record/action.yml
@@ -1,0 +1,68 @@
+# Publish to one store and record it, with the store's own answer as
+# the authority on what "already published" means.
+#
+# The record tag (`<prefix>-<store>-v<version>`, written by
+# `store-publish-state`) is what stops the next run re-publishing a
+# version a store already carries. It is written AFTER a successful
+# publish, so a publish that succeeds and a tag push that does not
+# leaves the repo believing the store still owes a publish. The next
+# run then submits the same version again and the store refuses it,
+# which is where this stalls: a store that already has the version can
+# never accept it, so nothing but a hand-made tag ever clears it.
+#
+# So a refusal that says the version is already there counts as
+# published, and the tag gets written. That is the same answer the
+# repo was trying to record in the first place, and it is the store
+# saying it, not us guessing. Every other failure still fails the job.
+name: publish-and-record
+description: >-
+  Run a store's publish command and record the version with the tag the
+  probe checked, treating "this version is already there" as published.
+inputs:
+  store:
+    description: The store's name, for the messages
+    required: true
+  run:
+    description: The publish command, run with bash
+    required: true
+  tag:
+    description: >-
+      The record tag, taken from `store-publish-state`'s `tags` output so
+      the probe and the recorder read the same string.
+    required: true
+runs:
+  using: composite
+  steps:
+    - name: publish to ${{ inputs.store }}
+      env:
+        STORE: ${{ inputs.store }}
+        PUBLISH: ${{ inputs.run }}
+        TAG: ${{ inputs.tag }}
+      shell: bash
+      run: |
+        set -uo pipefail
+        # The output is wanted whichever way this goes: on success it is
+        # the log, on failure it is the evidence for the check below.
+        out="$(bash -c "$PUBLISH" 2>&1)"
+        code=$?
+        printf '%s\n' "$out"
+        if [ "$code" -ne 0 ]; then
+          # Narrow on purpose. A pattern that matched loosely would
+          # record a tag for a publish that never happened, and that
+          # store would then be skipped forever: the failure this whole
+          # action exists to avoid, pointed the other way. Every store
+          # spells this refusal as "already exists" or "already
+          # published" (AMO puts the version first, ovsx puts it in the
+          # middle, so the version's position is not something to match
+          # on). No other failure any store returns says "already".
+          if grep -qiE 'already (exists|published|been published)' <<<"$out"; then
+            echo "::notice::${STORE} already carries this version, so there was nothing to publish; recording ${TAG}"
+          else
+            echo "::error::publishing to ${STORE} failed"
+            exit "$code"
+          fi
+        fi
+        { git tag "$TAG" && git push origin "$TAG"; } || {
+          echo "::error::${STORE} carries this version but ${TAG} could not be recorded; create it by hand (git tag ${TAG} ${GITHUB_SHA} && git push origin ${TAG}), or the next run will submit a version the store already has"
+          exit 1
+        }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -420,19 +420,14 @@ jobs:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           allow-no-subscriptions: true
-      - run: pnpm dlx @vscode/vsce@3.9.2 publish --packagePath "$GITHUB_WORKSPACE/weft-vscode.vsix" --azure-credential
-      - name: record the published version
-        env:
-          # The EXACT tag the probe checked (the composite is the one
-          # place the tag format exists), so probe and recorder can
-          # never drift into re-publishing an existing version.
-          TAG: ${{ fromJSON(needs.vsix.outputs.tags).marketplace }}
-        run: |
-          set -euo pipefail
-          { git tag "$TAG" && git push origin "$TAG"; } || {
-            echo "::error::published to the Marketplace but could not record $TAG; create it by hand (git tag $TAG ${GITHUB_SHA} && git push origin $TAG) or the next run will re-publish an existing version and fail"
-            exit 1
-          }
+      # The tag is the EXACT string the probe checked (the composite is
+      # the one place the format exists), so probe and recorder can
+      # never drift into re-publishing an existing version.
+      - uses: ./.github/actions/publish-and-record
+        with:
+          store: the VS Code Marketplace
+          run: pnpm dlx @vscode/vsce@3.9.2 publish --packagePath "$GITHUB_WORKSPACE/weft-vscode.vsix" --azure-credential
+          tag: ${{ fromJSON(needs.vsix.outputs.tags).marketplace }}
 
   publish-openvsx:
     name: publish to Open VSX
@@ -462,18 +457,13 @@ jobs:
           out="$(pnpm dlx ovsx@1.1.1 create-namespace weavemind -p "$OVSX_PAT" 2>&1)" \
             || { grep -qi "already exists" <<<"$out" || { printf '%s\n' "$out" >&2; exit 1; }; }
           printf '%s\n' "$out"
-      - env:
-          OVSX_PAT: ${{ secrets.OVSX_PAT }}
-        run: pnpm dlx ovsx@1.1.1 publish "$GITHUB_WORKSPACE/weft-vscode.vsix"
-      - name: record the published version
+      - uses: ./.github/actions/publish-and-record
         env:
-          TAG: ${{ fromJSON(needs.vsix.outputs.tags).openvsx }}
-        run: |
-          set -euo pipefail
-          { git tag "$TAG" && git push origin "$TAG"; } || {
-            echo "::error::published to Open VSX but could not record $TAG; create it by hand (git tag $TAG ${GITHUB_SHA} && git push origin $TAG) or the next run will re-publish an existing version and fail"
-            exit 1
-          }
+          OVSX_PAT: ${{ secrets.OVSX_PAT }}
+        with:
+          store: Open VSX
+          run: pnpm dlx ovsx@1.1.1 publish "$GITHUB_WORKSPACE/weft-vscode.vsix"
+          tag: ${{ fromJSON(needs.vsix.outputs.tags).openvsx }}
 
   publish-browser:
     name: publish to ${{ matrix.store }}
@@ -502,9 +492,23 @@ jobs:
         with:
           name: browser-zips
           path: extension-browser/build
-      - name: submit
+      # The per-store zip arguments live here because only this job
+      # knows which zips the packaging step wrote; the publish itself
+      # and its record go through the shared action.
+      - id: args
         env:
           STORE: ${{ matrix.store }}
+        run: |
+          set -euo pipefail
+          case "$STORE" in
+            chrome)  args="--chrome-zip build/weft-extension-chrome.zip" ;;
+            firefox) args="--firefox-zip build/weft-extension-firefox.zip --firefox-sources-zip build/weft-extension-sources.zip" ;;
+            edge)    args="--edge-zip build/weft-extension-edge.zip" ;;
+            *) echo "::error::no submit shape for store '$STORE'"; exit 1 ;;
+          esac
+          echo "value=$args" >> "$GITHUB_OUTPUT"
+      - uses: ./.github/actions/publish-and-record
+        env:
           CHROME_EXTENSION_ID: ${{ secrets.CHROME_EXTENSION_ID }}
           CHROME_CLIENT_ID: ${{ secrets.CHROME_CLIENT_ID }}
           CHROME_CLIENT_SECRET: ${{ secrets.CHROME_CLIENT_SECRET }}
@@ -520,25 +524,10 @@ jobs:
           EDGE_PRODUCT_ID: ${{ secrets.EDGE_PRODUCT_ID }}
           EDGE_CLIENT_ID: ${{ secrets.EDGE_CLIENT_ID }}
           EDGE_API_KEY: ${{ secrets.EDGE_API_KEY }}
-        # `exec` (not a bare command): pnpm only keeps -C for builtins
-        # and package scripts; an unknown bare command re-parses argv
-        # and dies on "extension-browser" as a command name.
-        run: |
-          set -euo pipefail
-          case "$STORE" in
-            chrome)  args="--chrome-zip build/weft-extension-chrome.zip" ;;
-            firefox) args="--firefox-zip build/weft-extension-firefox.zip --firefox-sources-zip build/weft-extension-sources.zip" ;;
-            edge)    args="--edge-zip build/weft-extension-edge.zip" ;;
-            *) echo "::error::no submit shape for store '$STORE'"; exit 1 ;;
-          esac
-          pnpm -C extension-browser exec wxt submit $args
-      - name: record the published version
-        env:
-          STORE: ${{ matrix.store }}
-          TAG: ${{ fromJSON(needs.browser.outputs.tags)[matrix.store] }}
-        run: |
-          set -euo pipefail
-          { git tag "$TAG" && git push origin "$TAG"; } || {
-            echo "::error::published to ${STORE} but could not record $TAG; create it by hand (git tag $TAG ${GITHUB_SHA} && git push origin $TAG) or the next run will re-publish an existing version and fail"
-            exit 1
-          }
+        with:
+          store: ${{ matrix.store }}
+          # `exec` (not a bare command): pnpm only keeps -C for builtins
+          # and package scripts; an unknown bare command re-parses argv
+          # and dies on "extension-browser" as a command name.
+          run: pnpm -C extension-browser exec wxt submit ${{ steps.args.outputs.value }}
+          tag: ${{ fromJSON(needs.browser.outputs.tags)[matrix.store] }}

--- a/extension-vscode/README.md
+++ b/extension-vscode/README.md
@@ -1,11 +1,13 @@
 # Weft for VS Code
 
-The editor side of [Weft](https://weavemindai.github.io/weft/), an
-open-source language and runtime for AI workflows (the source is on
-the [`mvp` branch](https://github.com/WeaveMindAI/weft/tree/mvp), where
-the rebuild lives; `main` is the old proof of concept). Open a `.weft` file
-and the extension shows it as a live graph; run it, and the graph
-lights up with the execution as it happens.
+The editor side of [Weft](https://weavemindai.github.io/weft/), a
+programming language and framework for AI orchestration: as flexible as
+an agent, as reliable as code. Open a `.weft` file and the extension
+shows it as a live graph; run it, and the graph lights up with the
+execution as it happens.
+
+Weft is made by [Weavemind](https://weavemind.ai) and developed in the
+open at [github.com/WeaveMindAI/weft](https://github.com/WeaveMindAI/weft).
 
 ## What you get
 
@@ -31,9 +33,20 @@ it is one script. By default the extension connects to
 `http://localhost:9999` (the local daemon); the `weft.dispatcherUrl`
 setting points it elsewhere.
 
+## What it does on your machine
+
+It talks to the weft runtime on `localhost` and to nothing else: no
+telemetry, no account, no outside service. To compile and run your
+programs it starts the `weft` command that the install script put on
+your PATH.
+
 ## Learn more
 
 The full documentation lives at
-[weavemindai.github.io/weft](https://weavemindai.github.io/weft/).
-Issues and contributions are welcome at
-[github.com/WeaveMindAI/weft](https://github.com/WeaveMindAI/weft).
+[weavemindai.github.io/weft](https://weavemindai.github.io/weft/), and
+questions and bug reports are welcome
+[on the issue tracker](https://github.com/WeaveMindAI/weft/issues).
+
+## License
+
+See [LICENSE](https://github.com/WeaveMindAI/weft/blob/mvp/LICENSE).

--- a/extension-vscode/package.json
+++ b/extension-vscode/package.json
@@ -1,8 +1,8 @@
 {
   "name": "weft-vscode",
   "displayName": "Weft",
-  "description": "Weft language support: project management against the local dispatcher, live graph view for .weft files, AI streaming edits.",
-  "version": "0.2.238",
+  "description": "Write Weft programs and watch them run: a live, editable graph of every .weft file, with diagnostics, runs and executions in the editor.",
+  "version": "0.2.239",
   "publisher": "weavemind",
   "license": "SEE LICENSE IN LICENSE",
   "repository": {
@@ -13,6 +13,23 @@
   "bugs": {
     "url": "https://github.com/WeaveMindAI/weft/issues"
   },
+  "keywords": [
+    "weft",
+    "workflow",
+    "orchestration",
+    "ai",
+    "llm",
+    "agents",
+    "graph",
+    "visual programming",
+    "automation"
+  ],
+  "galleryBanner": {
+    "color": "#1e1b2e",
+    "theme": "dark"
+  },
+  "pricing": "Free",
+  "qna": "https://github.com/WeaveMindAI/weft/issues",
   "packageManager": "pnpm@10.32.1",
   "engines": {
     "vscode": "^1.90.0"


### PR DESCRIPTION
Two things, both from today's release run.

**The publish record self-heals.** Each store's publish is recorded as a git tag, and the tag is written after the publish succeeds. A publish that succeeded whose tag push did not leaves the repo thinking the store still owes one; the next run re-submits, the store refuses the duplicate, and only a hand-made tag ever clears it. That is what the Firefox leg had been stuck on. A refusal that says the version is already there now records the tag instead of failing, since it is the store confirming exactly what the tag was meant to record. Everything else still fails the job. Checked the pattern against all five stores' real refusals and eight genuine failures (a review rejection, a bad credential, a timeout, a missing zip, rate limiting): the first five match, none of the rest do. The three copy-pasted record steps collapse into one composite action.

**The VS Code extension's metadata**, for the Marketplace listing: a description written for somebody who has never used weft, keywords (the field was absent), a gallery banner, `pricing: Free` stated, Q&A pointed at the issue tracker, and a README that names Weavemind up front and says what the extension does on your machine (localhost only, no telemetry, no account).

Weft is now live on the VS Code Marketplace at 0.2.239, uploaded through the portal after the automated path was blocked as "suspicious content". The record tags for what each store already carries are pushed, so this run publishes 0.2.239 to Open VSX and skips the stores that are already up to date.